### PR TITLE
Fix analyzer issue

### DIFF
--- a/flutter_navigation_generator/pubspec.yaml
+++ b/flutter_navigation_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  analyzer: ^5.0.0
+  analyzer: ^6.0.0
   build: ^2.3.1
   code_builder: ^4.5.0
   collection: ^1.16.0

--- a/flutter_navigation_generator/pubspec.yaml
+++ b/flutter_navigation_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  analyzer: ^6.0.0
+  analyzer: >=6.4.1 <7.0.0
   build: ^2.3.1
   code_builder: ^4.5.0
   collection: ^1.16.0


### PR DESCRIPTION
https://pub.dev/packages/injectable_generator/score


injectable_generator is using `analyzer: >=6.4.1 <7.0.0` so move this up to at lease 6.4.1 because starting from this version it requires dart 3.3